### PR TITLE
UISlider fix

### DIFF
--- a/GameContent/Systems/TankMusicSystem.cs
+++ b/GameContent/Systems/TankMusicSystem.cs
@@ -47,11 +47,11 @@ namespace WiiPlayTanksRemake.GameContent.Systems
 
             if (MapRenderer.Theme == MapTheme.Forest)
             {
-                forestAmbience.volume = GameConfig.AmbientVolume;
+                forestAmbience.volume = TankGame.Instance.Settings.AmbientVolume;
                 return;
             }
 
-            var musicVolume = GameConfig.MusicVolume;
+            var musicVolume = TankGame.Instance.Settings.MusicVolume;
 
             foreach (var song in songs.Where(sng => sng is not null))
                 song.volume = 0f;
@@ -366,6 +366,18 @@ namespace WiiPlayTanksRemake.GameContent.Systems
             forestAmbience?.Play();
             foreach (var song in songs)
                 song?.Play();
+        }
+
+        public static void UpdateVolume()
+        {
+            foreach (var song in songs)
+            {
+                if (song.volume > 0)
+                {
+                    song.volume = 0.5f * TankGame.Instance.Settings.MusicVolume;
+                    forestAmbience.volume = TankGame.Instance.Settings.AmbientVolume;
+                }
+            }
         }
     }
 }

--- a/GameContent/UI/IngameUI.cs
+++ b/GameContent/UI/IngameUI.cs
@@ -25,6 +25,12 @@ namespace WiiPlayTanksRemake.GameContent.UI
 
         public static UIImageButton OptionsButton;
 
+        public static UIImageButton BackButton;
+
+        internal static UISlider MusicVolume;
+
+        internal static UISlider AmbientVolume;
+
         public static bool Paused { get; set; } = false;
 
         public const int SETTINGS_BUTTONS_CT = 10;
@@ -56,15 +62,49 @@ namespace WiiPlayTanksRemake.GameContent.UI
             QuitButton.SetDimensions(700, 850, 500, 150);
             QuitButton.OnMouseClick += QuitButton_OnMouseClick;
 
+            MusicVolume = new();
+            MusicVolume.SetDimensions(700, 100, 500, 150);
+            MusicVolume.Initialize();
+            MusicVolume.Value = TankGame.Instance.Settings.MusicVolume;
+            MusicVolume.SliderColor = Color.WhiteSmoke;
+
+            AmbientVolume = new();
+            AmbientVolume.SetDimensions(700, 600, 500, 150);
+            AmbientVolume.Initialize();
+            AmbientVolume.Value = TankGame.Instance.Settings.AmbientVolume;
+            AmbientVolume.SliderColor = Color.WhiteSmoke;
+
+            BackButton = new(null, 1f, (uiImageButton, spriteBatch) => QuickButton(uiImageButton, spriteBatch, "Back", Color.WhiteSmoke));
+            BackButton.SetDimensions(700, 850, 500, 150);
+            BackButton.OnMouseClick += BackButton_OnMouseClick;
+
             ResumeButton.Visible = false;
             RestartButton.Visible = false;
             QuitButton.Visible = false;
             OptionsButton.Visible = false;
+            MusicVolume.Visible = false;
+            AmbientVolume.Visible = false;
+            BackButton.Visible = false;
+        }
+
+        private static void BackButton_OnMouseClick(Internals.UI.UIElement affectedElement)
+        {
+            InOptions = false;
+            MusicVolume.Visible = false;
+            AmbientVolume.Visible = false;
+            BackButton.Visible = false;
         }
 
         private static void OptionsButton_OnMouseClick(Internals.UI.UIElement affectedElement)
         {
             InOptions = true;
+            ResumeButton.Visible = false;
+            RestartButton.Visible = false;
+            QuitButton.Visible = false;
+            OptionsButton.Visible = false;
+            MusicVolume.Visible = true;
+            AmbientVolume.Visible = true;
+            BackButton.Visible = true;
         }
 
         private static void QuitButton_OnMouseClick(Internals.UI.UIElement affectedElement)
@@ -113,6 +153,14 @@ namespace WiiPlayTanksRemake.GameContent.UI
             MissionInfoBar.UniqueDraw =
                 (uiPanel, spriteBatch) => spriteBatch.DrawString(TankGame.Fonts.Default, text, uiPanel.Hitbox.Center.ToVector2(), Color.White, 0, drawOrigin, 1.5f, SpriteEffects.None, 1f);
             if (Pause.JustPressed) {
+                if (InOptions)
+                {
+                    InOptions = false;
+                    MusicVolume.Visible = false;
+                    AmbientVolume.Visible = false;
+                    BackButton.Visible = false;
+                    return;
+                }
                 if (Paused)
                     TankMusicSystem.ResumeAll();
                 else
@@ -120,15 +168,17 @@ namespace WiiPlayTanksRemake.GameContent.UI
                 Paused = !Paused;
             }
 
-            if (InOptions)
+            if (!InOptions)
             {
-
+                ResumeButton.Visible = Paused;
+                RestartButton.Visible = Paused;
+                QuitButton.Visible = Paused;
+                OptionsButton.Visible = Paused;
             }
 
-            ResumeButton.Visible = Paused;
-            RestartButton.Visible = Paused;
-            QuitButton.Visible = Paused;
-            OptionsButton.Visible = Paused;
+            TankGame.Instance.Settings.MusicVolume = MusicVolume.Value;
+            TankGame.Instance.Settings.AmbientVolume = AmbientVolume.Value;
+            TankMusicSystem.UpdateVolume();
         }
 
         public class Options

--- a/GameContent/WPTR.cs
+++ b/GameContent/WPTR.cs
@@ -52,8 +52,6 @@ namespace WiiPlayTanksRemake.GameContent
 
         public static Logger ClientLog { get; } = new($"{TankGame.ExePath}", "client");
 
-        private static UIElement lastElementClicked;
-
         public static bool InMission { get; set; } = false;
 
         public static Matrix UIMatrix => Matrix.CreateOrthographicOffCenter(0, TankGame.Instance.GraphicsDevice.Viewport.Width, TankGame.Instance.GraphicsDevice.Viewport.Height, 0, -1, 1);
@@ -159,6 +157,7 @@ namespace WiiPlayTanksRemake.GameContent
 
         public static int tankToSpawnType;
         public static int tankToSpawnTeam;
+        private static int _delay;
 
         internal static void DoRender()
         {
@@ -242,21 +241,15 @@ namespace WiiPlayTanksRemake.GameContent
                         element?.MouseLeave();
                         element.MouseHovering = false;
                     }
-                    if (Input.MouseLeft && GameUtils.MouseOnScreenProtected && element != lastElementClicked && element.Hitbox.Contains(GameUtils.MousePosition)) {
+                    if (Input.MouseLeft && (!Input.OldMouseLeft || element.GetType() == typeof(UIImage)) && GameUtils.MouseOnScreenProtected && element.Hitbox.Contains(GameUtils.MousePosition)) {
                         element?.MouseClick();
-                        lastElementClicked = element;
                     }
-                    if (Input.MouseRight && GameUtils.MouseOnScreenProtected && element != lastElementClicked && element.Hitbox.Contains(GameUtils.MousePosition)) {
+                    if (Input.MouseRight && !Input.OldMouseRight && GameUtils.MouseOnScreenProtected && element.Hitbox.Contains(GameUtils.MousePosition)) {
                         element?.MouseRightClick();
-                        lastElementClicked = element;
                     }
-                    if (Input.MouseMiddle && GameUtils.MouseOnScreenProtected && element != lastElementClicked && element.Hitbox.Contains(GameUtils.MousePosition)) {
+                    if (Input.MouseMiddle && !Input.OldMouseMiddle && GameUtils.MouseOnScreenProtected && element.Hitbox.Contains(GameUtils.MousePosition)) {
                         element?.MouseMiddleClick();
-                        lastElementClicked = element;
                     }
-                }
-                if (!Input.MouseLeft && !Input.MouseRight && !Input.MouseMiddle) {
-                    lastElementClicked = null;
                 }
             }
         }

--- a/GameContent/WPTR.cs
+++ b/GameContent/WPTR.cs
@@ -157,7 +157,6 @@ namespace WiiPlayTanksRemake.GameContent
 
         public static int tankToSpawnType;
         public static int tankToSpawnTeam;
-        private static int _delay;
 
         internal static void DoRender()
         {

--- a/Internals/Common/Framework/Audio/SoundPlayer.cs
+++ b/Internals/Common/Framework/Audio/SoundPlayer.cs
@@ -6,10 +6,10 @@ namespace WiiPlayTanksRemake.Internals.Common.Framework.Audio
 {
     public static class SoundPlayer
     {
-        private static float MasterVolume => GameConfig.MasterVolume;
-        private static float MusicVolume => GameConfig.MusicVolume;
-        private static float SoundVolume => GameConfig.SoundVolume;
-        private static float AmbientVolume => GameConfig.AmbientVolume;
+        private static float MasterVolume => TankGame.Instance.Settings.MasterVolume;
+        private static float MusicVolume => TankGame.Instance.Settings.MusicVolume;
+        private static float SoundVolume => TankGame.Instance.Settings.SoundVolume;
+        private static float AmbientVolume => TankGame.Instance.Settings.AmbientVolume;
         public static SoundEffectInstance PlaySoundInstance(SoundEffect fromSound, SoundContext context, float volume = 1f)
         {
             switch (context)

--- a/Internals/Common/GameUI/UISlider.cs
+++ b/Internals/Common/GameUI/UISlider.cs
@@ -27,10 +27,12 @@ namespace WiiPlayTanksRemake.Internals.Common.GameUI
 
 		public override void OnInitialize()
 		{
-			UIImage interactable = new(GameResources.GetGameResource<Texture2D>("Assets/MagicPixel"), 1f, (image, spriteBatch) => spriteBatch.Draw(image.Texture, image.Hitbox, SliderColor));
+			UIImage interactable = new(GameResources.GetGameResource<Texture2D>("Assets/MagicPixel"), 1f, (image, spriteBatch) => spriteBatch.Draw(image.Texture, image.Hitbox, Color.Transparent));
 			interactable.SetDimensions((int)Position.X + 2, (int)Position.Y + 2, (int)Size.X - 4, (int)Size.Y - 4);
 			interactable.OnMouseClick += (element) =>
 			{
+				if (!element.Parent.Visible || !element.Visible)
+					return;
 				int mouseXRelative = (int)Math.Round(Utilities.GameUtils.MouseX - element.Position.X);
 				InternalValue = MathHelper.Clamp(mouseXRelative / element.Size.X, 0, 1);
 			};

--- a/Internals/Common/Input.cs
+++ b/Internals/Common/Input.cs
@@ -20,6 +20,9 @@ namespace WiiPlayTanksRemake.Internals.Common
         public static GamePadState OldGamePadSnapshot { get; internal set; }
 
         public static void HandleInput(PlayerIndex pIndex = PlayerIndex.One) {
+            OldKeySnapshot = CurrentKeySnapshot;
+            OldMouseSnapshot = CurrentMouseSnapshot;
+            OldGamePadSnapshot = CurrentGamePadSnapshot;
             CurrentKeySnapshot = Keyboard.GetState();
             CurrentMouseSnapshot = Mouse.GetState();
             CurrentGamePadSnapshot = GamePad.GetState(pIndex);
@@ -41,6 +44,9 @@ namespace WiiPlayTanksRemake.Internals.Common
         public static bool MouseLeft => CurrentMouseSnapshot.LeftButton == ButtonState.Pressed;
         public static bool MouseMiddle => CurrentMouseSnapshot.MiddleButton == ButtonState.Pressed;
         public static bool MouseRight => CurrentMouseSnapshot.RightButton == ButtonState.Pressed;
+        public static bool OldMouseLeft => OldMouseSnapshot.LeftButton == ButtonState.Pressed;
+        public static bool OldMouseMiddle => OldMouseSnapshot.MiddleButton == ButtonState.Pressed;
+        public static bool OldMouseRight => OldMouseSnapshot.RightButton == ButtonState.Pressed;
         public static bool CanDetectClick(bool rightClick = false) {
             bool clicked = !rightClick ? (CurrentMouseSnapshot.LeftButton == ButtonState.Pressed && OldMouseSnapshot.LeftButton == ButtonState.Released)
                 : (CurrentMouseSnapshot.RightButton == ButtonState.Pressed && OldMouseSnapshot.RightButton == ButtonState.Released);

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -35,10 +35,10 @@ namespace WiiPlayTanksRemake
         public float AmbientVolume { get; set; } = 1f;
 
         #region Graphics Settings
-        public static int TankFootprintLimit { get; set; }
-        public static int PerPixelLighting { get; set; }
-        public static bool Vsync { get; set; }
-        public static bool BorderlessWindow { get; set; } = true;
+        public int TankFootprintLimit { get; set; }
+        public int PerPixelLighting { get; set; }
+        public bool Vsync { get; set; }
+        public bool BorderlessWindow { get; set; } = true;
 
         #endregion
     }

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -199,7 +199,7 @@ namespace WiiPlayTanksRemake
 
             IsMouseVisible = false;
 
-            Window.IsBorderless = GameConfig.BorderlessWindow;
+            Window.IsBorderless = true;
         }
         protected override void Initialize()
         {
@@ -236,6 +236,7 @@ namespace WiiPlayTanksRemake
                 SettingsHandler = new(Settings, SaveDirectory + Path.DirectorySeparatorChar + "settings.json");
                 Settings = SettingsHandler.DeserializeAndSet<GameConfig>();
             }
+            Window.IsBorderless = Settings.BorderlessWindow;
 
             GameView = Matrix.CreateLookAt(new(0f, 0f, 120f), Vector3.Zero, Vector3.Up) * Matrix.CreateRotationX(0.75f) * Matrix.CreateTranslation(0f, 0f, 1000f);
             GameProjection = Matrix.CreateOrthographic(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height, -2000f, 5000f);

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Text;
+using System.Text.Json;
 using System.Reflection;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
@@ -29,10 +29,10 @@ namespace WiiPlayTanksRemake
 
     public class GameConfig
     {
-        public static float MasterVolume { get; set; } = 1f;
-        public static float MusicVolume { get; set; } = 0.5f;
-        public static float SoundVolume { get; set; } = 1f;
-        public static float AmbientVolume { get; set; } = 1f;
+        public float MasterVolume { get; set; } = 1f;
+        public float MusicVolume { get; set; } = 0.5f;
+        public float SoundVolume { get; set; } = 1f;
+        public float AmbientVolume { get; set; } = 1f;
 
         #region Graphics Settings
         public static int TankFootprintLimit { get; set; }
@@ -41,8 +41,8 @@ namespace WiiPlayTanksRemake
         public static bool BorderlessWindow { get; set; } = true;
 
         #endregion
-
     }
+
     public class Camera
     {
         private Matrix _viewMatrix;
@@ -226,8 +226,10 @@ namespace WiiPlayTanksRemake
             if (!File.Exists(SaveDirectory + Path.DirectorySeparatorChar + "settings.json")) {
                 Settings = new();
                 SettingsHandler = new(Settings, SaveDirectory + Path.DirectorySeparatorChar + "settings.json");
-                System.Text.Json.JsonSerializerOptions opts = new();
-                opts.WriteIndented = true;
+                JsonSerializerOptions opts = new()
+                {
+                    WriteIndented = true
+                };
                 SettingsHandler.Serialize(opts, true);
             }
             else {
@@ -246,6 +248,12 @@ namespace WiiPlayTanksRemake
         protected override void OnExiting(object sender, EventArgs args)
         {
             WPTR.ClientLog.Dispose();
+            SettingsHandler = new(Settings, SaveDirectory + Path.DirectorySeparatorChar + "settings.json");
+            JsonSerializerOptions opts = new()
+            {
+                WriteIndented = true
+            };
+            SettingsHandler.Serialize(opts, true);
         }
 
         protected override void LoadContent()
@@ -364,9 +372,6 @@ namespace WiiPlayTanksRemake
                         tnk.IsHoveredByMouse = false;
                 }
             }
-            Input.OldKeySnapshot = Input.CurrentKeySnapshot;
-            Input.OldMouseSnapshot = Input.CurrentMouseSnapshot;
-            Input.OldGamePadSnapshot = Input.CurrentGamePadSnapshot;
             foreach (var music in Music.AllMusic)
                 music?.Update();
         }


### PR DESCRIPTION
Fixed `UISlider` and started the options menu.

Note there is still an issue with `UIElement` click detection where the `UISlider` will snap to the last clicked position if an overlayed `UIElement` was clicked just prior to the `UISlider` - look into this or I will fix later.