### PR TITLE
Fix draw of non-valid characters in debug printing

### DIFF
--- a/Internals/Common/Utilities/DebugUtils.cs
+++ b/Internals/Common/Utilities/DebugUtils.cs
@@ -18,29 +18,6 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
         public static bool DebuggingEnabled { get; set; }
         public static int DebugLevel { get; set; }
 
-        /// <summary>
-        /// Remove non-valid font characters from the given text to be safe-to-draw
-        /// </summary>
-        /// <param name="font">Font to check valid characters</param>
-        /// <param name="text">Text to valid</param>
-        /// <returns>Safe-to-draw text</returns>
-        public static void GetSafeFontText(SpriteFont font, string defaultText, out string text)
-        {
-            text = "";
-
-            foreach (char letter in defaultText)
-			{
-                if (letter == '\n' || letter == '\r' || font.Characters.Contains(letter))
-                {
-                    text += letter;
-                }
-                else
-                { 
-                    text += "?";
-				}
-			}
-        }
-
         private static readonly string[] DebuggingNames =
         {
             "General",
@@ -56,7 +33,7 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
             if (beginSb)
                 sb.Begin();
 
-            GetSafeFontText(TankGame.Fonts.Default, info.ToString(), out string text);
+            SpriteFontUtils.GetSafeText(TankGame.Fonts.Default, info.ToString(), out string text);
             sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(text) / 2 : default, scaleOverride * 0.6f, default, default); 
 
             if (beginSb)

--- a/Internals/Common/Utilities/DebugUtils.cs
+++ b/Internals/Common/Utilities/DebugUtils.cs
@@ -24,18 +24,22 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
         /// <param name="font">Font to check valid characters</param>
         /// <param name="text">Text to valid</param>
         /// <returns>Safe-to-draw text</returns>
-        public static string GetSafeFontText(SpriteFont font, string text)
-		{
-            string safeText = "";
+        public static void GetSafeFontText(SpriteFont font, string defaultText, out string text)
+        {
+            text = "";
 
-            foreach (char letter in text)
+            foreach (char letter in defaultText)
+			{
                 if (letter == '\n' || letter == '\r' || font.Characters.Contains(letter))
-                    safeText += letter;
+                {
+                    text += letter;
+                }
                 else
-                    safeText += "?";
-
-            return safeText;
-		}
+                { 
+                    text += "?";
+				}
+			}
+        }
 
         private static readonly string[] DebuggingNames =
         {
@@ -52,7 +56,7 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
             if (beginSb)
                 sb.Begin();
 
-            string text = GetSafeFontText(TankGame.Fonts.Default, info.ToString());
+            GetSafeFontText(TankGame.Fonts.Default, info.ToString(), out string text);
             sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(text) / 2 : default, scaleOverride * 0.6f, default, default); 
 
             if (beginSb)

--- a/Internals/Common/Utilities/DebugUtils.cs
+++ b/Internals/Common/Utilities/DebugUtils.cs
@@ -18,6 +18,25 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
         public static bool DebuggingEnabled { get; set; }
         public static int DebugLevel { get; set; }
 
+        /// <summary>
+        /// Remove non-valid font characters from the given text to be safe-to-draw
+        /// </summary>
+        /// <param name="font">Font to check valid characters</param>
+        /// <param name="text">Text to valid</param>
+        /// <returns>Safe-to-draw text</returns>
+        public static string GetSafeFontText(SpriteFont font, string text)
+		{
+            string safeText = "";
+
+            foreach (char letter in text)
+                if (letter == '\n' || letter == '\r' || font.Characters.Contains(letter))
+                    safeText += letter;
+                else
+                    safeText += "?";
+
+            return safeText;
+		}
+
         private static readonly string[] DebuggingNames =
         {
             "General",
@@ -33,7 +52,8 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
             if (beginSb)
                 sb.Begin();
 
-            sb.DrawString(TankGame.Fonts.Default, info.ToString(), position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(info.ToString()) / 2 : default, scaleOverride * 0.6f, default, default); 
+            string text = GetSafeFontText(TankGame.Fonts.Default, info.ToString());
+            sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString( text ) / 2 : default, scaleOverride * 0.6f, default, default); 
 
             if (beginSb)
                 sb.End();

--- a/Internals/Common/Utilities/DebugUtils.cs
+++ b/Internals/Common/Utilities/DebugUtils.cs
@@ -33,8 +33,7 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
             if (beginSb)
                 sb.Begin();
 
-            SpriteFontUtils.GetSafeText(TankGame.Fonts.Default, info.ToString(), out string text);
-            sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(text) / 2 : default, scaleOverride * 0.6f, default, default); 
+            sb.DrawString(TankGame.Fonts.Default, info.ToString(), position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(info.ToString()) / 2 : default, scaleOverride * 0.6f, default, default); 
 
             if (beginSb)
                 sb.End();

--- a/Internals/Common/Utilities/DebugUtils.cs
+++ b/Internals/Common/Utilities/DebugUtils.cs
@@ -53,7 +53,7 @@ namespace WiiPlayTanksRemake.Internals.Common.Utilities
                 sb.Begin();
 
             string text = GetSafeFontText(TankGame.Fonts.Default, info.ToString());
-            sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString( text ) / 2 : default, scaleOverride * 0.6f, default, default); 
+            sb.DrawString(TankGame.Fonts.Default, text, position, Color.White, 0f, centerIt ? TankGame.Fonts.Default.MeasureString(text) / 2 : default, scaleOverride * 0.6f, default, default); 
 
             if (beginSb)
                 sb.End();

--- a/Internals/Common/Utilities/SpriteFontUtils.cs
+++ b/Internals/Common/Utilities/SpriteFontUtils.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiPlayTanksRemake.Internals.Common.Utilities
+{
+	public static class SpriteFontUtils
+	{
+        /// <summary>
+        /// Remove non-valid font characters from the given text to be safe-to-draw
+        /// </summary>
+        /// <param name="font">Font to check valid characters</param>
+        /// <param name="text">Text to valid</param>
+        /// <param name="validText">Variable to output the valid text</param>
+        public static void GetSafeText(this SpriteFont font, string text, out string validText)
+        {
+            validText = "";
+
+            foreach (char letter in text)
+            {
+                if (letter == '\n' || letter == '\r' || font.Characters.Contains(letter))
+                {
+                    validText += letter;
+                }
+                else
+                {
+                    validText += "?";
+                }
+            }
+        }
+    }
+}

--- a/TankGame.cs
+++ b/TankGame.cs
@@ -175,6 +175,7 @@ namespace WiiPlayTanksRemake
         public static string SysCPU = $"CPU: {GetHardware("Win32_Processor", "Name")}";
         public static string SysKeybd = $"Keyboard: {GetHardware("Win32_Keyboard", "Name")}";
         public static string SysMouse = $"Mouse: {GetHardware("Win32_PointingDevice", "Name")}";
+        public static string SysText;
 
         private static Stopwatch RenderStopwatch { get; } = new();
         private static Stopwatch UpdateStopwatch { get; } = new();
@@ -312,6 +313,8 @@ namespace WiiPlayTanksRemake
             TankModel_Player = GameResources.GetGameResource<Model>("Assets/tank_p");
 
             Fonts.Default = GameResources.GetGameResource<SpriteFont>("Assets/DefaultFont");
+            SpriteFontUtils.GetSafeText(Fonts.Default, $"{SysGPU}\n{SysCPU}\n{SysKeybd}\n{SysMouse}", out SysText);
+            
             spriteBatch = new SpriteBatch(GraphicsDevice);
             UITextures.UIPanelBackground = GameResources.GetGameResource<Texture2D>("Assets/UIPanelBackground");
             WhitePixel = GameResources.GetGameResource<Texture2D>("Assets/MagicPixel");
@@ -438,11 +441,7 @@ namespace WiiPlayTanksRemake
 
             spriteBatch.DrawString(Fonts.Default, "Debug Level: " + DebugUtils.CurDebugLabel, new Vector2(10), Color.White, 0f, default, 0.6f, default, default);
             DebugUtils.DrawDebugString(spriteBatch, $"Memory Used: {MemoryParser.FromMegabytes(TotalMemoryUsed)} MB", new(8, GameUtils.WindowHeight * 0.18f));
-            DebugUtils.DrawDebugString(spriteBatch, $"{SysGPU}" +
-                $"\n{SysCPU}" +
-                $"\n{SysKeybd}" +
-                $"\n{SysMouse}",
-                new(8, GameUtils.WindowHeight * 0.2f));
+            DebugUtils.DrawDebugString(spriteBatch, SysText, new(8, GameUtils.WindowHeight * 0.2f));
 
             graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
 


### PR DESCRIPTION
Depending on the user language, the hardware name could have dyacritics which are not supported by the default font. Just made a function to remove invalid characters from a specified text and for a given font.