### PR TITLE
Resolve Issue w/ Duplicate Attributes

### DIFF
--- a/TankGame.cs
+++ b/TankGame.cs
@@ -26,8 +26,6 @@ using WiiPlayTanksRemake.Internals.Common.Framework.Graphics;
 using WiiPlayTanksRemake.GameContent.Systems;
 using WiiPlayTanksRemake.Net;
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
 namespace WiiPlayTanksRemake
 {
     // TODO: Implement block once all of above things are done

--- a/WiiPlayTanksRemake.csproj
+++ b/WiiPlayTanksRemake.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
This pull request allows the game to compile once again by fixing an issue with conflicting assembly-wide attributes due to manually defining values for `AssemblyVersionAttribute` and `AssemblyFileVersionAttribute`.

Moving forward, please keep in mind that these are intended to be modified in your `.csproj`. Also keep in mind that `AssemblyFileVersion` inherits the value of `AssemblyVersion`.