### PR TITLE
fix user tank freaking out at FPS < 36

### DIFF
--- a/GameContent/Tanks/PlayerTank.cs
+++ b/GameContent/Tanks/PlayerTank.cs
@@ -197,7 +197,7 @@ public class PlayerTank : Tank {
         properties.MineStun = 1; // 8
         properties.Invisible = false;
         properties.Acceleration = 0.3f;
-        properties.Deceleration = 0.3f;
+        properties.Deceleration = 0.6f;
         properties.TurningSpeed = 0.1f;
 
         // this changes depending on input (or should it?)

--- a/GameContent/Tanks/PlayerTank.cs
+++ b/GameContent/Tanks/PlayerTank.cs
@@ -197,7 +197,7 @@ public class PlayerTank : Tank {
         properties.MineStun = 1; // 8
         properties.Invisible = false;
         properties.Acceleration = 0.3f;
-        properties.Deceleration = 0.6f;
+        properties.Deceleration = 0.3f;
         properties.TurningSpeed = 0.1f;
 
         // this changes depending on input (or should it?)

--- a/GameContent/Tanks/Tank.cs
+++ b/GameContent/Tanks/Tank.cs
@@ -520,17 +520,12 @@ public abstract class Tank(bool ignoresRegister) {
                 ChassisRotation -= MathHelper.Pi;
                 DrawParamsTank.GraphicalFlip = !DrawParamsTank.GraphicalFlip;
             }
-        };
-
-        if (!IsTurning) {
-            Speed += Properties.Acceleration * RuntimeData.DeltaTime;
-
-            if (Speed > Properties.MaxSpeed)
-                Speed = Properties.MaxSpeed;
-        }
-        else
             // used to be 1f - DeltaTime
-            Speed *= Properties.Deceleration * RuntimeData.DeltaTime;
+            Speed = Math.Max(0f, Speed - Properties.Deceleration * RuntimeData.DeltaTime);
+        }
+        else {
+            Speed = Math.Min(Properties.MaxSpeed, Speed + Properties.Acceleration * RuntimeData.DeltaTime);
+        }
 
         // bigkitty told me that stuns instantly apply zero-velocity
         if (CurShootStun > 0 || CurMineStun > 0 || Properties.Stationary || !CampaignGlobals.InMission && !MainMenuUI.IsActive) {

--- a/GameContent/Tanks/Tank.cs
+++ b/GameContent/Tanks/Tank.cs
@@ -521,7 +521,7 @@ public abstract class Tank(bool ignoresRegister) {
                 DrawParamsTank.GraphicalFlip = !DrawParamsTank.GraphicalFlip;
             }
             // used to be 1f - DeltaTime
-            Speed = Math.Max(0f, Speed - Properties.Deceleration * RuntimeData.DeltaTime);
+            Speed *= (float)Math.Pow(Properties.Deceleration, RuntimeData.DeltaTime);
         }
         else {
             Speed = Math.Min(Properties.MaxSpeed, Speed + Properties.Acceleration * RuntimeData.DeltaTime);


### PR DESCRIPTION
Fixes tank deceleration code for lower FPS.

Because DeltaTime is a ratio of 60fps/current framerate, any framerate below 36 would cause the deceleration code to speed up the tank instead of slow it down, and since it is *=, instead of exponential decay (the intent?) it is exponential growth.

EG imagine an FPS 20 scenario:
- DeltaTime = 3
- Player Releases control keys
- Tank 'decelerates' by Speed *= Deceleration * DeltaTime
- aka Speed = Speed * .6f * 3
- aka every frame Speed = Speed * 1.8
- aka zoom zoom all crazy like :)
